### PR TITLE
Update Elasticsearch query for labels

### DIFF
--- a/elastic-query.py
+++ b/elastic-query.py
@@ -3,6 +3,7 @@
 import argparse
 from datetime import datetime
 import getopt
+import re
 import sys
 
 from elasticsearch import Elasticsearch
@@ -14,8 +15,7 @@ def main():
     pod's application, component and namespace."""
 
     desc = ('Query elasticsearch indexes for logs, using a pods name and'
-            ' namespace, or by label values for the pods application, '
-            ' component, and namespace.'
+            ' namespace, or by label key:value pairs for the pod(s).'
             ' ex. \"elastic-query.py'
             ' --query pod'
             ' --uri http://admin:changeme@elasticsearch-logging.osh-infra:80'
@@ -25,50 +25,43 @@ def main():
             ' \"elastic-query.py'
             ' --query labels'
             ' --uri http://admin:changeme@elasticsearch-logging.osh-infra:80'
-            ' --app elasticsearch'
-            ' --component test'
-            ' --namespace osh-infra\"')
+            ' --labels kubernetes.labels.application:elasticsearch'
+            ' kubernetes.labels.component:test')
     parser = argparse.ArgumentParser(description=desc)
     parser.add_argument(
-        '--query',
+        '--query','-q',
         metavar='query',
         type=str,
         required=True,
         default="pod",
         help='Query type: pod name or kubernetes labels')
     parser.add_argument(
-        '--uri',
+        '--uri','-u',
         metavar='uri',
         type=str,
         required=True,
         help='Elasticsearch URI (with credentials if basic auth enabled)')
     parser.add_argument(
-        '--index',
+        '--index','-i',
         metavar='index',
         type=str,
         required=False,
         default='_all',
         help='Elasticsearch index to search')
     parser.add_argument(
-        '--pod',
+        '--pod','-p',
         metavar='pod',
         type=str,
         required=False,
         help='Name of the pod to retrieve logs for')
     parser.add_argument(
-        '--app',
-        metavar='app',
-        type=str,
+        '--labels','-l',
+        nargs='+',
+        metavar='labels',
         required=False,
-        help='The Kubernetes label "application" on the pod(s)')
+        help='List of key:values for labels to query')
     parser.add_argument(
-        '--component',
-        metavar='component',
-        type=str,
-        required=False,
-        help='The kubernetes label "component" on the pod(s)')
-    parser.add_argument(
-        '--namespace',
+        '--namespace','-n',
         metavar='namespace',
         type=str,
         required=False,
@@ -81,8 +74,8 @@ def main():
     if args.query == "pod":
         search = pod_query(es, args.pod, args.namespace, args.index)
     elif args.query == "labels":
-        search = label_query(es, args.app, args.component,
-                             args.namespace, args.index)
+        print(args.labels)
+        search = label_query(es, args.labels, args.index)
     else:
         print("I'm sorry Dave, I'm afraid I can't do that")
         exit(1)
@@ -100,12 +93,14 @@ def pod_query(es, pod, namespace, index):
     return search
 
 
-def label_query(es, application, component, namespace, index):
-    search = Search(using=es, index=index) \
-        .filter({"term": {"kubernetes.labels.component": component}}) \
-        .filter({"term": {"kubernetes.labels.application": application}}) \
-        .filter({"term": {"kubernetes.namespace_name.keyword": namespace}}) \
-        .sort('@timestamp', {"order": "asc"})
+def label_query(es, labels, index):
+    search = Search(using=es, index=index)
+    for label in labels:
+        label_parts = re.split(':', label)
+        label_key = label_parts[0]
+        label_value = label_parts[1]
+        search = search.filter({"term": {label_key: label_value}})
+    search = search.sort('@timestamp', {"order": "asc"})
     return search
 
 


### PR DESCRIPTION
This updates the query by label functionality to instead take a
list of arbitrary key:value pairs to use for the labels to query
against, instead of assuming the standard kubernetes labels will
be present